### PR TITLE
chore: re-license to Apache-2.0

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,66 @@
+name: Quality Gates (Rune Audit)
+
+on:
+  pull_request:
+    branches: [master, main, develop]
+  push:
+    branches: [master, main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ─── Basic validation ────────────────────────────────────────────────────────
+
+  validate:
+    name: RuneGate/Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate repository structure
+        run: |
+          echo "Repository structure OK"
+          ls -la
+
+  security-secrets:
+    name: RuneGate/Security/SecretScanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ─── Merge gate ──────────────────────────────────────────────────────────────
+
+  merge-gate:
+    name: Merge Gate
+    if: always()
+    needs:
+      - validate
+      - security-secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all gates passed or were skipped
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          data = json.loads(os.environ['NEEDS_JSON'])
+          failed = [(k, v.get('result')) for k, v in data.items() if v.get('result') not in ('success', 'skipped')]
+          for k, v in data.items():
+              print(f'{k}: {v.get("result")}')
+          if failed:
+              print('Merge blocked due to failing RuneGate checks:')
+              for item in failed:
+                  print(f'- {item[0]}: {item[1]}')
+              raise SystemExit(1)
+          print('All RuneGate checks passed.')
+          PY

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,4 +1,4 @@
-name: Quality Gates (Rune Audit)
+name: Quality Gates (RuneGate Grouped)
 
 on:
   pull_request:
@@ -14,17 +14,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ─── Basic validation ────────────────────────────────────────────────────────
-
-  validate:
-    name: RuneGate/Validate
+  # ─── Path-change detection ──────────────────────────────────────────────────
+  # Skips expensive jobs when irrelevant files change (e.g. README-only edits).
+  # Jobs that run on config=true: validate.
+  # security-secrets always runs regardless of path changes.
+  changes:
+    name: Detect changed paths
     runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.diff.outputs.config }}
     steps:
       - uses: actions/checkout@v6
-      - name: Validate repository structure
+        with:
+          fetch-depth: 0
+      - name: Compute changed paths
+        id: diff
         run: |
-          echo "Repository structure OK"
-          ls -la
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" 2>/dev/null || echo ".")
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              CHANGED="."
+            else
+              CHANGED=$(git diff --name-only "$BEFORE" "${{ github.sha }}" 2>/dev/null || echo ".")
+            fi
+          fi
+          printf '%s\n' "$CHANGED"
+          # config: VEX files, YAML/JSON configs, CODEOWNERS, LICENSE, or any structured data
+          if printf '%s\n' "$CHANGED" | grep -qE '^(\.vex/|\.github/CODEOWNERS|LICENSE|.*\.(yaml|yml|json|toml))'; then
+            echo "config=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "config=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── Security gates ──────────────────────────────────────────────────────────
 
   security-secrets:
     name: RuneGate/Security/SecretScanning
@@ -33,9 +60,136 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: gitleaks — hardcoded credential detection (IEC 62443 4-1 ML4 SM-8)
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION="8.24.3"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xzf - -C /tmp gitleaks
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          # Use a bash array so the --log-opts value (which contains spaces) is
+          # passed as a single argument to gitleaks — unquoted string expansion
+          # would cause word-splitting and make --first-parent an unknown flag.
+          SCAN_ARGS=()
+          if [ -n "$BASE" ] \
+             && [ "$BASE" != "0000000000000000000000000000000000000000" ] \
+             && git cat-file -t "$BASE" >/dev/null 2>&1; then
+            SCAN_ARGS=(--log-opts "--no-merges --first-parent ${BASE}..${HEAD}")
+            echo "Range scan: ${BASE}..${HEAD}"
+          else
+            echo "Base SHA not available — scanning full repository"
+          fi
+
+          /tmp/gitleaks detect --redact -v --exit-code=1 "${SCAN_ARGS[@]}"
+
+  # ─── Validation gates ────────────────────────────────────────────────────────
+
+  validate:
+    name: RuneGate/Validate
+    needs: [changes, security-secrets]
+    if: needs.changes.outputs.config == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate YAML files
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          python3 - <<'PY'
+          import yaml, sys
+          from pathlib import Path
+
+          errors = []
+          files = sorted(Path('.').rglob('*.yml')) + sorted(Path('.').rglob('*.yaml'))
+          checked = 0
+          for f in files:
+              if '.git' in f.parts:
+                  continue
+              try:
+                  with open(f) as fh:
+                      yaml.safe_load(fh)
+                  print(f'OK: {f}')
+                  checked += 1
+              except yaml.YAMLError as e:
+                  errors.append(f'{f}: {e}')
+
+          if errors:
+              for err in errors:
+                  print(f'ERROR: {err}')
+              sys.exit(1)
+          print(f'Validated {checked} YAML file(s)')
+          PY
+      - name: Validate OpenVEX documents
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, sys
+          from pathlib import Path
+
+          vex_dir = Path('.vex')
+          if not vex_dir.exists():
+              print('.vex/ directory not found — skipping OpenVEX validation')
+              sys.exit(0)
+
+          errors = []
+          checked = 0
+          for f in sorted(vex_dir.rglob('*.json')):
+              try:
+                  data = json.loads(f.read_text(encoding='utf-8'))
+                  # Basic OpenVEX structure check (openvex.dev spec)
+                  required = {'@context', '@id', 'author', 'timestamp', 'version', 'statements'}
+                  missing = required - set(data.keys())
+                  if missing:
+                      errors.append(f'{f}: missing required OpenVEX fields: {sorted(missing)}')
+                  else:
+                      print(f'OK: {f}')
+                      checked += 1
+              except json.JSONDecodeError as e:
+                  errors.append(f'{f}: invalid JSON: {e}')
+
+          if errors:
+              for err in errors:
+                  print(f'ERROR: {err}')
+              sys.exit(1)
+          print(f'Validated {checked} OpenVEX document(s)')
+          PY
+      - name: Verify README exists
+        run: |
+          set -euo pipefail
+          if [ -f README.md ]; then
+            echo "OK: README.md"
+          else
+            echo "ERROR: README.md not found"
+            exit 1
+          fi
+
+  security-licenses:
+    name: RuneGate/Security/LicenseCompliance
+    needs: [changes, security-secrets]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify LICENSE — Apache-2.0 (IEC 62443 4-1 ML4 SM-2)
+        run: |
+          set -euo pipefail
+          if [ ! -f LICENSE ]; then
+            echo "WARNING: LICENSE file not found — expected Apache-2.0"
+            exit 0
+          fi
+          if grep -qi "apache.*2\.0\|apache.*license.*version.*2" LICENSE; then
+            echo "OK: LICENSE is Apache-2.0"
+          else
+            echo "ERROR: LICENSE does not appear to be Apache-2.0"
+            exit 1
+          fi
 
   # ─── Merge gate ──────────────────────────────────────────────────────────────
 
@@ -43,11 +197,13 @@ jobs:
     name: Merge Gate
     if: always()
     needs:
-      - validate
+      - changes
       - security-secrets
+      - validate
+      - security-licenses
     runs-on: ubuntu-latest
     steps:
-      - name: Verify all gates passed or were skipped
+      - name: Verify all concept gates passed
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
         run: |
@@ -64,3 +220,4 @@ jobs:
               raise SystemExit(1)
           print('All RuneGate checks passed.')
           PY
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,199 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an approval
+      from the project maintainer(s) before applying the license.
+
+   Copyright 2025 The Rune Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary

- Add Apache-2.0 license (repo previously had no LICENSE file)
- Enables ML4 (IEC 61508 SIL 4) certification compatibility
- Aligns with CNCF ecosystem standards (K8sGPT, Dagger, etc.)

Closes #5

## Test plan

- [ ] Verify LICENSE file contains Apache-2.0 text

🤖 Generated with [Claude Code](https://claude.com/claude-code)