### PR TITLE
docs: redirect README to rune-docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Instructions
+All RUNE engineering standards, architecture, and SOPs are consolidated in the central documentation hub:
+https://github.com/lpasquali/rune-docs/blob/main/docs/context/SYSTEM_PROMPT.md
+
+Before suggesting code, refactoring, or performing tasks, you MUST reference the following files in the 'rune-docs' repository:
+- docs/context/SYSTEM_PROMPT.md (Core Identity & SOP)
+- docs/context/CODING_STANDARDS.md (Testing & Visuals)
+- docs/context/CURRENT_STATE.md (Living Memory)
+
+Do not use local or cached project-specific instructions; use 'rune-docs' as the only source of truth.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# RUNE Audit & Evidence Engine
+# RUNE (Reliability Use-case Numeric Evaluator) — Audit
+
+Auditing and compliance tracking for the RUNE platform.
+
+## 📖 Documentation
+All documentation is consolidated in **[rune-docs](https://github.com/lpasquali/rune-docs)**.
+
+## 🛡️ Compliance
+- **ML4**: This repository aligns with **IEC 62443-4-1 ML4** secure development requirements.
+- **SLSA**: Build provenance follows **SLSA Level 3**.
+
+## 📜 License
+Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
Updated README to point to the central rune-docs hub.