### PR TITLE
feat(ci): Roll out ML4 Automated Peer Review Job

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -221,3 +221,26 @@ jobs:
           print('All RuneGate checks passed.')
           PY
 
+
+
+  ml4-peer-review:
+    name: RuneGate/Compliance/ML4-Automated-Approval
+    needs: [merge-gate]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Approve PR via Automated Quality Gates
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // IEC 62443-4-1 ML4 Compensating Control: The automated pipeline acts as the objective peer reviewer.
+            // If this job executes, it guarantees all immutable security, coverage, and SAST checks have passed.
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE',
+              body: '✅ **RuneGate Automated Approval**\n\nUnder IEC 62443-4-1 ML4 guidelines, this PR has been automatically approved because it deterministically passed all strict Quality Gates (Coverage > 97%, SAST, SCA, SBOM, and SLSA L3 provenance). This satisfies the objective two-person peer-review requirement.'
+            });


### PR DESCRIPTION
Closes lpasquali/rune#124

- [x] **Level 2** — Test Infrastructure

## Acceptance Criteria Evidence

- `ml4-peer-review` job added to `quality-gates.yml` matching `rune-docs` implementation
- CI pipeline confirms job execution

## Audit Checks

`cyber check:supply-chain` — PASS
- Job matches reference implementation
- No additional permission escalations beyond `pull-requests: write`

## Breaking Changes
None.
