### PR TITLE
fix: use urlparse for URL validation (CodeQL High)

### DIFF
--- a/rune_audit/models/slsa.py
+++ b/rune_audit/models/slsa.py
@@ -10,6 +10,7 @@ import base64
 import json
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field
 
@@ -87,7 +88,7 @@ class SLSAAttestation(BaseModel):
         resolved = build_def.get("resolvedDependencies", [])
         for dep in resolved:
             uri = dep.get("uri", "")
-            if "github.com" in uri:
+            if urlparse(uri).hostname in ("github.com", "www.github.com"):
                 digest = dep.get("digest", {})
                 source_ref = digest.get("gitCommit", "")
                 break


### PR DESCRIPTION
## Summary

- fix: use urlparse for URL validation (CodeQL High)

Closes #44

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation

## Acceptance Criteria Evidence

- CI passes with fix applied

## Audit Checks

cyber check:supply-chain — PASS (security/CI config change only)

## Breaking Changes

None.