### PR TITLE
fix: add SPDX-License-Identifier headers to all Python files

### DIFF
--- a/rune_audit/__init__.py
+++ b/rune_audit/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """rune-audit: Auditing and compliance tracking for the RUNE platform."""
 
 __version__ = "0.0.0a0"

--- a/rune_audit/__main__.py
+++ b/rune_audit/__main__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Entry point for ``rune-audit`` console script."""
 
 from __future__ import annotations

--- a/rune_audit/cli/__init__.py
+++ b/rune_audit/cli/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI command modules for rune-audit."""
 
 from rune_audit.cli.app import app

--- a/rune_audit/cli/app.py
+++ b/rune_audit/cli/app.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Main Typer application for rune-audit CLI.
 
 Registers all command groups and provides the ``rune-audit`` entry point.

--- a/rune_audit/cli/collect.py
+++ b/rune_audit/cli/collect.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for evidence collection."""
 
 from __future__ import annotations

--- a/rune_audit/cli/compliance.py
+++ b/rune_audit/cli/compliance.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for compliance reporting."""
 
 from __future__ import annotations

--- a/rune_audit/cli/config_cmd.py
+++ b/rune_audit/cli/config_cmd.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for configuration display."""
 
 from __future__ import annotations

--- a/rune_audit/cli/report.py
+++ b/rune_audit/cli/report.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for report generation."""
 
 from __future__ import annotations

--- a/rune_audit/cli/slsa_cmd.py
+++ b/rune_audit/cli/slsa_cmd.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for SLSA verification."""
 
 from __future__ import annotations

--- a/rune_audit/cli/vex.py
+++ b/rune_audit/cli/vex.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CLI commands for VEX document management."""
 
 from __future__ import annotations

--- a/rune_audit/collectors/__init__.py
+++ b/rune_audit/collectors/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Evidence collectors for rune-audit."""

--- a/rune_audit/collectors/base.py
+++ b/rune_audit/collectors/base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Base collector protocol."""
 
 from __future__ import annotations

--- a/rune_audit/collectors/github.py
+++ b/rune_audit/collectors/github.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """GitHub Actions artifact collector.
 
 Collects SBOM, CVE scans, SLSA attestations, and gate results from

--- a/rune_audit/collectors/vex.py
+++ b/rune_audit/collectors/vex.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """VEX document collector.
 
 Fetches OpenVEX documents from RUNE repositories via the GitHub Contents API.

--- a/rune_audit/config.py
+++ b/rune_audit/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Configuration loading for rune-audit.
 
 Reads settings from environment variables and optional ``rune-audit.yaml`` file.

--- a/rune_audit/models/__init__.py
+++ b/rune_audit/models/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Evidence data models for RUNE audit."""
 
 from rune_audit.models.attestation import AttestationResult

--- a/rune_audit/models/attestation.py
+++ b/rune_audit/models/attestation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """TPM2 attestation result models."""
 
 from __future__ import annotations

--- a/rune_audit/models/cve.py
+++ b/rune_audit/models/cve.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """CVE (Common Vulnerabilities and Exposures) scan result models.
 
 Parses Grype and Trivy JSON output formats.

--- a/rune_audit/models/evidence.py
+++ b/rune_audit/models/evidence.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Unified evidence bundle that aggregates all evidence types.
 
 The EvidenceBundle is the central data structure consumed by the compliance

--- a/rune_audit/models/gate.py
+++ b/rune_audit/models/gate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Quality gate result models."""
 
 from __future__ import annotations

--- a/rune_audit/models/sbom.py
+++ b/rune_audit/models/sbom.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SBOM (Software Bill of Materials) evidence models.
 
 Parses CycloneDX JSON format as produced by Syft.

--- a/rune_audit/models/slsa.py
+++ b/rune_audit/models/slsa.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SLSA (Supply-chain Levels for Software Artifacts) attestation models.
 
 Models for SLSA L3 build provenance attestations as produced by

--- a/rune_audit/models/vex.py
+++ b/rune_audit/models/vex.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """VEX (Vulnerability Exploitability eXchange) document models."""
 
 from __future__ import annotations

--- a/rune_audit/reporters/__init__.py
+++ b/rune_audit/reporters/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Report generators for audit results (Markdown, JSON, HTML)."""

--- a/rune_audit/reporters/compliance.py
+++ b/rune_audit/reporters/compliance.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """IEC 62443 ML4 compliance evidence matrix generator.
 
 Maps evidence artifacts to IEC 62443-4-1 ML4 requirements and generates

--- a/rune_audit/validators/__init__.py
+++ b/rune_audit/validators/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Validators for rune-audit."""
 
 from rune_audit.validators.vex_validator import VEXValidator

--- a/rune_audit/validators/vex_validator.py
+++ b/rune_audit/validators/vex_validator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """VEX document validator.
 
 Validates OpenVEX documents for structural correctness, cross-references

--- a/rune_audit/verifiers/__init__.py
+++ b/rune_audit/verifiers/__init__.py
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 """Verification engines for rune-audit."""

--- a/rune_audit/verifiers/slsa.py
+++ b/rune_audit/verifiers/slsa.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """SLSA Level 3 provenance verifier.
 
 Verifies that build attestations meet all five SLSA L3 requirements:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared pytest fixtures for rune-audit tests."""
 
 from __future__ import annotations

--- a/tests/test_cli/test_cli_main.py
+++ b/tests/test_cli/test_cli_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for rune-audit CLI."""
 
 from __future__ import annotations

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for all CLI command groups."""
 
 from __future__ import annotations

--- a/tests/test_cli/test_entrypoint.py
+++ b/tests/test_cli/test_entrypoint.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for __main__ entry point."""
 
 from __future__ import annotations

--- a/tests/test_collectors/test_base.py
+++ b/tests/test_collectors/test_base.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for base collector protocol."""
 
 from __future__ import annotations

--- a/tests/test_collectors/test_fixtures.py
+++ b/tests/test_collectors/test_fixtures.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests verifying test fixtures load correctly."""
 
 from __future__ import annotations

--- a/tests/test_collectors/test_github.py
+++ b/tests/test_collectors/test_github.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for GitHub Actions artifact collector."""
 
 from __future__ import annotations

--- a/tests/test_collectors/test_vex_collector.py
+++ b/tests/test_collectors/test_vex_collector.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for VEX document collector."""
 
 from __future__ import annotations

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for configuration loading."""
 
 from __future__ import annotations

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for package-level attributes."""
 
 from __future__ import annotations

--- a/tests/test_models/test_attestation.py
+++ b/tests/test_models/test_attestation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for TPM2 attestation result models."""
 
 from rune_audit.models.attestation import AttestationResult

--- a/tests/test_models/test_config.py
+++ b/tests/test_models/test_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for configuration loading."""
 
 from __future__ import annotations

--- a/tests/test_models/test_cve.py
+++ b/tests/test_models/test_cve.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for CVE scan result models."""
 
 from __future__ import annotations

--- a/tests/test_models/test_evidence.py
+++ b/tests/test_models/test_evidence.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for evidence bundle model."""
 
 from rune_audit.models.cve import CVEFinding, CVEScanResult, CVESeverity

--- a/tests/test_models/test_gate.py
+++ b/tests/test_models/test_gate.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for quality gate result models."""
 
 from rune_audit.models.gate import GateResult, GateStatus

--- a/tests/test_models/test_sbom.py
+++ b/tests/test_models/test_sbom.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for SBOM data models."""
 
 from __future__ import annotations

--- a/tests/test_models/test_slsa.py
+++ b/tests/test_models/test_slsa.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for SLSA attestation data models."""
 
 from __future__ import annotations

--- a/tests/test_models/test_vex.py
+++ b/tests/test_models/test_vex.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for VEX document models."""
 
 from typing import Any

--- a/tests/test_reporters/test_compliance.py
+++ b/tests/test_reporters/test_compliance.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for IEC 62443 ML4 compliance evidence matrix generator."""
 
 from __future__ import annotations

--- a/tests/test_validators/test_vex_validator.py
+++ b/tests/test_validators/test_vex_validator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for VEX document validator."""
 
 from __future__ import annotations

--- a/tests/test_verifiers/conftest.py
+++ b/tests/test_verifiers/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Shared fixtures for verifier tests."""
 
 from __future__ import annotations

--- a/tests/test_verifiers/test_slsa.py
+++ b/tests/test_verifiers/test_slsa.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Tests for the SLSA Level 3 provenance verifier."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Add `# SPDX-License-Identifier: Apache-2.0` to all Python source files
- Required for IEC 62443 ML4 legal compliance and REUSE specification

Closes #52

## DoD Level

- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure (header-only change, no runtime impact)
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- [x] All .py files have SPDX header as first line
- [x] Tests pass with no regressions

## Audit Checks

No triggers fired — no dependencies, CI, or API changes.

## Breaking Changes

None.

## Test plan

- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)