### PR TITLE
feat: implement audit report generator

### DIFF
--- a/rune_audit/cli/report.py
+++ b/rune_audit/cli/report.py
@@ -38,7 +38,7 @@ def report_full(
     """Generate a complete audit report."""
     cfg = AuditConfig.load(config_file)
     evidence = _load_evidence(cfg)
-    content = ReportGenerator(evidence).generate_full(format=output_format)
+    content = ReportGenerator(evidence).generate_full(output_format=output_format)
     _write_output(content, output, "Full Audit Report")
 
 @report_app.command("summary")
@@ -50,7 +50,7 @@ def report_summary(
     """Generate an executive summary."""
     cfg = AuditConfig.load(config_file)
     evidence = _load_evidence(cfg)
-    content = ReportGenerator(evidence).generate_summary(format=output_format)
+    content = ReportGenerator(evidence).generate_summary(output_format=output_format)
     _write_output(content, output, "Audit Summary")
 
 @report_app.command("delta")
@@ -64,5 +64,5 @@ def report_delta(
     cfg = AuditConfig.load(config_file)
     evidence = _load_evidence(cfg)
     previous = EvidenceBundle(repos=cfg.repos)
-    content = ReportGenerator(evidence).generate_delta(previous, format=output_format)
+    content = ReportGenerator(evidence).generate_delta(previous, output_format=output_format)
     _write_output(content, output, "Delta Report (since " + (since or "last audit") + ")")

--- a/rune_audit/reporters/report_generator.py
+++ b/rune_audit/reporters/report_generator.py
@@ -21,21 +21,21 @@ class ReportGenerator:
         self._evidence = evidence
         self._compliance_gen = ComplianceMatrixGenerator()
 
-    def generate_full(self, format: str = "markdown") -> str:
+    def generate_full(self, output_format: str = "markdown") -> str:
         data = self._build_full_data()
-        if format == "json":
+        if output_format == "json":
             return json.dumps(data, indent=2, default=str)
         return self._render_full_markdown(data)
 
-    def generate_summary(self, format: str = "markdown") -> str:
+    def generate_summary(self, output_format: str = "markdown") -> str:
         data = self._build_summary_data()
-        if format == "json":
+        if output_format == "json":
             return json.dumps(data, indent=2, default=str)
         return self._render_summary_markdown(data)
 
-    def generate_delta(self, previous: EvidenceBundle, format: str = "markdown") -> str:
+    def generate_delta(self, previous: EvidenceBundle, output_format: str = "markdown") -> str:
         data = self._build_delta_data(previous)
-        if format == "json":
+        if output_format == "json":
             return json.dumps(data, indent=2, default=str)
         return self._render_delta_markdown(data)
 
@@ -190,168 +190,168 @@ class ReportGenerator:
         return recs
 
     def _render_full_markdown(self, data: dict[str, Any]) -> str:
-        L = []
-        L.append(f"# {data['title']}")
-        L.append("")
-        L.append(f"Generated: {data['generated_at']}")
-        L.append(f"Repositories: {', '.join(data['repos'])}")
-        L.append("")
+        lines = []
+        lines.append(f"# {data['title']}")
+        lines.append("")
+        lines.append(f"Generated: {data['generated_at']}")
+        lines.append(f"Repositories: {', '.join(data['repos'])}")
+        lines.append("")
         es = data["executive_summary"]
-        L.append("## Executive Summary")
-        L.append("")
-        L.append(f"- **Repos covered**: {es['total_repos']}")
-        L.append("- **Gates passing**: " + ("Yes" if es["gates_passing"] else "No"))
-        L.append(f"- **Total CVEs**: {es['total_cves']}")
-        L.append(f"- **Critical CVEs**: {es['critical_cves']}")
-        L.append(f"- **High CVEs**: {es['high_cves']}")
-        L.append(f"- **Compliance**: {es['compliance_met']}/{es['compliance_total']} requirements met")
-        L.append("")
+        lines.append("## Executive Summary")
+        lines.append("")
+        lines.append(f"- **Repos covered**: {es['total_repos']}")
+        lines.append("- **Gates passing**: " + ("Yes" if es["gates_passing"] else "No"))
+        lines.append(f"- **Total CVEs**: {es['total_cves']}")
+        lines.append(f"- **Critical CVEs**: {es['critical_cves']}")
+        lines.append(f"- **High CVEs**: {es['high_cves']}")
+        lines.append(f"- **Compliance**: {es['compliance_met']}/{es['compliance_total']} requirements met")
+        lines.append("")
         sb = data["sbom_analysis"]
-        L.append("## SBOM Analysis")
-        L.append("")
-        L.append(f"- **Total components**: {sb['total_components']}")
-        L.append(f"- **SBOMs collected**: {sb['sbom_count']}")
+        lines.append("## SBOM Analysis")
+        lines.append("")
+        lines.append(f"- **Total components**: {sb['total_components']}")
+        lines.append(f"- **SBOMs collected**: {sb['sbom_count']}")
         if sb["license_breakdown"]:
-            L.append("- **License breakdown**:")
+            lines.append("- **License breakdown**:")
             for lic, count in sb["license_breakdown"].items():
-                L.append(f"  - {lic}: {count}")
-        L.append("")
+                lines.append(f"  - {lic}: {count}")
+        lines.append("")
         cv = data["cve_findings"]
-        L.append("## CVE Findings")
-        L.append("")
-        L.append(f"Total findings: {cv['total']}")
+        lines.append("## CVE Findings")
+        lines.append("")
+        lines.append(f"Total findings: {cv['total']}")
         if cv["by_severity"]:
-            L.append("")
-            L.append("| Severity | Count |")
-            L.append("|---|---|")
+            lines.append("")
+            lines.append("| Severity | Count |")
+            lines.append("|---|---|")
             for sev, cnt in cv["by_severity"].items():
-                L.append(f"| {sev} | {cnt} |")
+                lines.append(f"| {sev} | {cnt} |")
         if cv["findings"]:
-            L.append("")
-            L.append("| CVE | Severity | CVSS | Package | Version | Fix |")
-            L.append("|---|---|---|---|---|---|")
+            lines.append("")
+            lines.append("| CVE | Severity | CVSS | Package | Version | Fix |")
+            lines.append("|---|---|---|---|---|---|")
             for f in cv["findings"]:
                 cs = f["cvss_score"] if f["cvss_score"] is not None else "N/A"
                 fx = f["fixed_version"] or "None"
-                L.append(f"| {f['cve_id']} | {f['severity']} | {cs} | {f['package']} | {f['version']} | {fx} |")
-        L.append("")
+                lines.append(f"| {f['cve_id']} | {f['severity']} | {cs} | {f['package']} | {f['version']} | {fx} |")
+        lines.append("")
         vx = data["vex_status"]
-        L.append("## VEX Status")
-        L.append("")
-        L.append(f"- **VEX documents**: {vx['total_documents']}")
-        L.append(f"- **Total statements**: {vx['total_statements']}")
-        L.append(f"- **Suppressed CVEs**: {len(vx['suppressed_cves'])}")
-        L.append(f"- **Unsuppressed CVEs**: {len(vx['unsuppressed_cves'])}")
-        L.append("")
+        lines.append("## VEX Status")
+        lines.append("")
+        lines.append(f"- **VEX documents**: {vx['total_documents']}")
+        lines.append(f"- **Total statements**: {vx['total_statements']}")
+        lines.append(f"- **Suppressed CVEs**: {len(vx['suppressed_cves'])}")
+        lines.append(f"- **Unsuppressed CVEs**: {len(vx['unsuppressed_cves'])}")
+        lines.append("")
         sl = data["slsa_verification"]
-        L.append("## SLSA Verification")
-        L.append("")
+        lines.append("## SLSA Verification")
+        lines.append("")
         if sl:
-            L.append("| Repository | Verified | Builder |")
-            L.append("|---|---|---|")
+            lines.append("| Repository | Verified | Builder |")
+            lines.append("|---|---|---|")
             for repo, info in sl.items():
                 v = "Yes" if info["verified"] else "No"
-                L.append(f"| {repo} | {v} | {info['builder_id']} |")
+                lines.append(f"| {repo} | {v} | {info['builder_id']} |")
         else:
-            L.append("No SLSA attestations collected.")
-        L.append("")
+            lines.append("No SLSA attestations collected.")
+        lines.append("")
         cm = data["compliance_matrix"]
-        L.append("## Compliance Matrix")
-        L.append("")
-        L.append(f"Summary: {cm['met']}/{cm['total']} requirements met")
-        L.append("")
-        L.append("| Requirement | Description | Status | Gaps |")
-        L.append("|---|---|---|---|")
+        lines.append("## Compliance Matrix")
+        lines.append("")
+        lines.append(f"Summary: {cm['met']}/{cm['total']} requirements met")
+        lines.append("")
+        lines.append("| Requirement | Description | Status | Gaps |")
+        lines.append("|---|---|---|---|")
         for req in cm["requirements"]:
             gs = "; ".join(req["gaps"]) if req["gaps"] else "None"
-            L.append(f"| {req['id']} | {req['description']} | **{req['status']}** | {gs} |")
-        L.append("")
-        L.append("## Recommendations")
-        L.append("")
+            lines.append(f"| {req['id']} | {req['description']} | **{req['status']}** | {gs} |")
+        lines.append("")
+        lines.append("## Recommendations")
+        lines.append("")
         for rec in data["recommendations"]:
-            L.append(f"- {rec}")
-        L.append("")
-        return "\n".join(L)
+            lines.append(f"- {rec}")
+        lines.append("")
+        return "\n".join(lines)
 
     def _render_summary_markdown(self, data: dict[str, Any]) -> str:
-        L = []
-        L.append(f"# {data['title']}")
-        L.append("")
-        L.append(f"Generated: {data['generated_at']}")
-        L.append(f"Overall status: **{data['overall_status']}**")
-        L.append("")
+        lines = []
+        lines.append(f"# {data['title']}")
+        lines.append("")
+        lines.append(f"Generated: {data['generated_at']}")
+        lines.append(f"Overall status: **{data['overall_status']}**")
+        lines.append("")
         km = data["key_metrics"]
-        L.append("## Key Metrics")
-        L.append("")
-        L.append(f"- **Repos covered**: {km['repos_covered']}")
-        L.append("- **Gates passing**: " + ("Yes" if km["gates_passing"] else "No"))
-        L.append(f"- **Total CVEs**: {km['total_cves']}")
-        L.append(f"- **Critical CVEs**: {km['critical_cves']}")
-        L.append(f"- **High CVEs**: {km['high_cves']}")
-        L.append(f"- **Compliance**: {km['compliance_met']}/{km['compliance_total']} requirements met")
-        L.append(f"- **SLSA verified**: {km['slsa_verified']}")
-        L.append("")
+        lines.append("## Key Metrics")
+        lines.append("")
+        lines.append(f"- **Repos covered**: {km['repos_covered']}")
+        lines.append("- **Gates passing**: " + ("Yes" if km["gates_passing"] else "No"))
+        lines.append(f"- **Total CVEs**: {km['total_cves']}")
+        lines.append(f"- **Critical CVEs**: {km['critical_cves']}")
+        lines.append(f"- **High CVEs**: {km['high_cves']}")
+        lines.append(f"- **Compliance**: {km['compliance_met']}/{km['compliance_total']} requirements met")
+        lines.append(f"- **SLSA verified**: {km['slsa_verified']}")
+        lines.append("")
         if data["critical_findings"]:
-            L.append("## Critical Findings")
-            L.append("")
-            L.append("| CVE | Severity | CVSS | Package |")
-            L.append("|---|---|---|---|")
+            lines.append("## Critical Findings")
+            lines.append("")
+            lines.append("| CVE | Severity | CVSS | Package |")
+            lines.append("|---|---|---|---|")
             for f in data["critical_findings"]:
                 cs = f["cvss_score"] if f["cvss_score"] is not None else "N/A"
-                L.append(f"| {f['cve_id']} | {f['severity']} | {cs} | {f['package']} |")
-            L.append("")
-        return "\n".join(L)
+                lines.append(f"| {f['cve_id']} | {f['severity']} | {cs} | {f['package']} |")
+            lines.append("")
+        return "\n".join(lines)
 
     def _render_delta_markdown(self, data: dict[str, Any]) -> str:
-        L = []
-        L.append(f"# {data['title']}")
-        L.append("")
-        L.append(f"Generated: {data['generated_at']}")
-        L.append(f"Comparing against: {data['previous_collected_at']}")
-        L.append("")
+        lines = []
+        lines.append(f"# {data['title']}")
+        lines.append("")
+        lines.append(f"Generated: {data['generated_at']}")
+        lines.append(f"Comparing against: {data['previous_collected_at']}")
+        lines.append("")
         cc = data["cve_changes"]
-        L.append("## CVE Changes")
-        L.append("")
+        lines.append("## CVE Changes")
+        lines.append("")
         if cc["new_cves"]:
-            L.append("**New CVEs:**")
+            lines.append("**New CVEs:**")
             for cid in cc["new_cves"]:
-                L.append(f"- {cid}")
+                lines.append(f"- {cid}")
         else:
-            L.append("No new CVEs.")
-        L.append("")
+            lines.append("No new CVEs.")
+        lines.append("")
         if cc["resolved_cves"]:
-            L.append("**Resolved CVEs:**")
+            lines.append("**Resolved CVEs:**")
             for cid in cc["resolved_cves"]:
-                L.append(f"- {cid}")
+                lines.append(f"- {cid}")
         else:
-            L.append("No resolved CVEs.")
-        L.append("")
+            lines.append("No resolved CVEs.")
+        lines.append("")
         cp = data["component_changes"]
-        L.append("## Component Changes")
-        L.append("")
+        lines.append("## Component Changes")
+        lines.append("")
         if cp["new_components"]:
-            L.append("**New components:**")
+            lines.append("**New components:**")
             for c in cp["new_components"]:
-                L.append(f"- {c}")
+                lines.append(f"- {c}")
         else:
-            L.append("No new components.")
-        L.append("")
+            lines.append("No new components.")
+        lines.append("")
         if cp["removed_components"]:
-            L.append("**Removed components:**")
+            lines.append("**Removed components:**")
             for c in cp["removed_components"]:
-                L.append(f"- {c}")
+                lines.append(f"- {c}")
         else:
-            L.append("No removed components.")
-        L.append("")
+            lines.append("No removed components.")
+        lines.append("")
         cch = data["compliance_changes"]
-        L.append("## Compliance Changes")
-        L.append("")
+        lines.append("## Compliance Changes")
+        lines.append("")
         if cch:
-            L.append("| Requirement | Previous | Current |")
-            L.append("|---|---|---|")
+            lines.append("| Requirement | Previous | Current |")
+            lines.append("|---|---|---|")
             for ch in cch:
-                L.append(f"| {ch['requirement']} | {ch['previous']} | {ch['current']} |")
+                lines.append(f"| {ch['requirement']} | {ch['previous']} | {ch['current']} |")
         else:
-            L.append("No compliance status changes.")
-        L.append("")
-        return "\n".join(L)
+            lines.append("No compliance status changes.")
+        lines.append("")
+        return "\n".join(lines)

--- a/tests/test_reporters/test_report_generator.py
+++ b/tests/test_reporters/test_report_generator.py
@@ -55,42 +55,42 @@ def _make_full_bundle():
 
 class TestGenerateFullMarkdown:
     def test_sections_present(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         for s in ["# RUNE Audit Report", "## Executive Summary", "## SBOM Analysis",
                    "## CVE Findings", "## VEX Status", "## SLSA Verification",
                    "## Compliance Matrix", "## Recommendations"]:
             assert s in report
     def test_sbom_data(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         assert "Total components**: 3" in report and "MIT" in report
     def test_cve_findings(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         assert "CVE-2024-1234" in report and "High" in report
     def test_vex_status(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         assert "VEX documents**: 1" in report
     def test_slsa(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         assert "lpasquali/rune" in report and "Yes" in report
     def test_recommendations_with_high_cve(self):
-        report = ReportGenerator(_make_full_bundle()).generate_full(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_full(output_format="markdown")
         assert "Upgrade test-pkg to 2.0.1" in report
 
 class TestGenerateFullJson:
     def test_valid(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(output_format="json"))
         assert data["title"] == "RUNE Audit Report"
     def test_cve_findings(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(output_format="json"))
         assert data["cve_findings"]["total"] == 2
     def test_slsa(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(output_format="json"))
         assert data["slsa_verification"]["lpasquali/rune"]["verified"] is True
     def test_compliance(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(output_format="json"))
         assert data["compliance_matrix"]["total"] > 0
     def test_recommendations(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_full(output_format="json"))
         assert len(data["recommendations"]) > 0
 
 class TestGenerateSummary:
@@ -100,108 +100,124 @@ class TestGenerateSummary:
                           GateResult(gate_name="secret-scan", status=GateStatus.PASS, source_repo="lpasquali/rune"),
                           GateResult(gate_name="sast-check", status=GateStatus.PASS, source_repo="lpasquali/rune")],
             sboms=[_make_sbom()], vex_documents=[_make_vex_doc()], slsa_attestations=[_make_slsa()])
-        report = ReportGenerator(bundle).generate_summary(format="markdown")
+        report = ReportGenerator(bundle).generate_summary(output_format="markdown")
         assert "# RUNE Audit Summary" in report and "Critical Findings" not in report
     def test_with_critical_cves(self):
-        report = ReportGenerator(_make_full_bundle()).generate_summary(format="markdown")
+        report = ReportGenerator(_make_full_bundle()).generate_summary(output_format="markdown")
         assert "## Critical Findings" in report and "CVE-2024-1234" in report
     def test_needs_attention(self):
         bundle = EvidenceBundle(repos=["lpasquali/rune"],
             gate_results=[GateResult(gate_name="sast-check", status=GateStatus.FAIL, source_repo="lpasquali/rune")])
-        report = ReportGenerator(bundle).generate_summary(format="markdown")
+        report = ReportGenerator(bundle).generate_summary(output_format="markdown")
         assert "NEEDS ATTENTION" in report
     def test_json(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_summary(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_summary(output_format="json"))
         assert data["title"] == "RUNE Audit Summary" and data["key_metrics"]["total_cves"] == 2
     def test_json_overall_status(self):
-        data = json.loads(ReportGenerator(_make_full_bundle()).generate_summary(format="json"))
+        data = json.loads(ReportGenerator(_make_full_bundle()).generate_summary(output_format="json"))
         assert data["overall_status"] in ("PASS", "NEEDS ATTENTION")
 
 class TestGenerateDelta:
     def test_new_cves(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[_make_cve_scan()])).generate_delta(
-            EvidenceBundle(repos=["lpasquali/rune"]), format="markdown")
+            EvidenceBundle(repos=["lpasquali/rune"]), output_format="markdown")
         assert "CVE-2024-1234" in report and "New CVEs" in report
     def test_resolved_cves(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"])).generate_delta(
-            EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[_make_cve_scan()]), format="markdown")
+            EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[_make_cve_scan()]), output_format="markdown")
         assert "Resolved CVEs" in report and "CVE-2024-1234" in report
     def test_new_components(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], sboms=[_make_sbom()])).generate_delta(
-            EvidenceBundle(repos=["lpasquali/rune"]), format="markdown")
+            EvidenceBundle(repos=["lpasquali/rune"]), output_format="markdown")
         assert "New components" in report and "pydantic@2.7.0" in report
     def test_removed_components(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"])).generate_delta(
-            EvidenceBundle(repos=["lpasquali/rune"], sboms=[_make_sbom()]), format="markdown")
+            EvidenceBundle(repos=["lpasquali/rune"], sboms=[_make_sbom()]), output_format="markdown")
         assert "Removed components" in report and "pydantic@2.7.0" in report
     def test_compliance_changes(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"],
             gate_results=[GateResult(gate_name="license-check", status=GateStatus.PASS, source_repo="lpasquali/rune")]
-        )).generate_delta(EvidenceBundle(repos=["lpasquali/rune"]), format="markdown")
+        )).generate_delta(EvidenceBundle(repos=["lpasquali/rune"]), output_format="markdown")
         assert "Compliance Changes" in report
     def test_no_changes(self):
         b = EvidenceBundle(repos=["lpasquali/rune"])
-        report = ReportGenerator(b).generate_delta(b, format="markdown")
+        report = ReportGenerator(b).generate_delta(b, output_format="markdown")
         for msg in ["No new CVEs.", "No resolved CVEs.", "No new components.",
                      "No removed components.", "No compliance status changes."]:
             assert msg in report
     def test_json(self):
         data = json.loads(ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"],
             cve_scans=[_make_cve_scan()], sboms=[_make_sbom()])).generate_delta(
-            EvidenceBundle(repos=["lpasquali/rune"]), format="json"))
+            EvidenceBundle(repos=["lpasquali/rune"]), output_format="json"))
         assert "CVE-2024-1234" in data["cve_changes"]["new_cves"]
         assert len(data["component_changes"]["new_components"]) == 3
 
 class TestEdgeCases:
     def test_empty_bundle_full(self):
-        report = ReportGenerator(EvidenceBundle(repos=[])).generate_full(format="markdown")
+        report = ReportGenerator(EvidenceBundle(repos=[])).generate_full(output_format="markdown")
         assert "Total components**: 0" in report and "Total findings: 0" in report
         assert "No SLSA attestations collected." in report
     def test_empty_bundle_summary(self):
-        report = ReportGenerator(EvidenceBundle(repos=[])).generate_summary(format="markdown")
+        report = ReportGenerator(EvidenceBundle(repos=[])).generate_summary(output_format="markdown")
         assert "Repos covered**: 0" in report
     def test_empty_bundle_delta(self):
         b = EvidenceBundle(repos=[])
-        assert "# RUNE Audit Delta Report" in ReportGenerator(b).generate_delta(b, format="markdown")
+        result = ReportGenerator(b).generate_delta(b, output_format="markdown")
+        assert "# RUNE Audit Delta Report" in result
+
     def test_only_sboms(self):
-        report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], sboms=[_make_sbom()])).generate_full(format="markdown")
+        gen = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], sboms=[_make_sbom()]))
+        report = gen.generate_full(output_format="markdown")
         assert "Total components**: 3" in report and "Total findings: 0" in report
+
     def test_only_cves(self):
-        report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[_make_cve_scan()])).generate_full(format="markdown")
+        gen = ReportGenerator(
+            EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[_make_cve_scan()]),
+        )
+        report = gen.generate_full(output_format="markdown")
         assert "Total components**: 0" in report and "CVE-2024-1234" in report
+
     def test_only_slsa(self):
-        report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"], slsa_attestations=[_make_slsa()])).generate_full(format="markdown")
+        gen = ReportGenerator(
+            EvidenceBundle(repos=["lpasquali/rune"], slsa_attestations=[_make_slsa()]),
+        )
+        report = gen.generate_full(output_format="markdown")
         assert "lpasquali/rune" in report
     def test_critical_cve_rec(self):
-        bundle = EvidenceBundle(repos=["lpasquali/rune"], cve_scans=[CVEScanResult(
-            findings=[CVEFinding(cve_id="CVE-2024-9999", severity=CVESeverity.CRITICAL, cvss_score=10.0, package_name="vulnerable-pkg")],
-            source_repo="lpasquali/rune")])
-        assert "CRITICAL: Remediate CVE-2024-9999" in ReportGenerator(bundle).generate_full(format="markdown")
+        finding = CVEFinding(
+            cve_id="CVE-2024-9999", severity=CVESeverity.CRITICAL,
+            cvss_score=10.0, package_name="vulnerable-pkg",
+        )
+        bundle = EvidenceBundle(
+            repos=["lpasquali/rune"],
+            cve_scans=[CVEScanResult(findings=[finding], source_repo="lpasquali/rune")],
+        )
+        assert "CRITICAL: Remediate CVE-2024-9999" in ReportGenerator(bundle).generate_full(output_format="markdown")
     def test_no_issues_rec(self):
         bundle = EvidenceBundle(repos=["lpasquali/rune"],
             gate_results=[GateResult(gate_name="license-check", status=GateStatus.PASS, source_repo="lpasquali/rune"),
                           GateResult(gate_name="secret-scan", status=GateStatus.PASS, source_repo="lpasquali/rune"),
                           GateResult(gate_name="sast-check", status=GateStatus.PASS, source_repo="lpasquali/rune")],
             sboms=[_make_sbom()], vex_documents=[_make_vex_doc()], slsa_attestations=[_make_slsa()])
-        data = json.loads(ReportGenerator(bundle).generate_full(format="json"))
+        data = json.loads(ReportGenerator(bundle).generate_full(output_format="json"))
         assert isinstance(data["recommendations"], list)
     def test_slsa_not_verified(self):
         report = ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"],
-            slsa_attestations=[_make_slsa(verified=False)])).generate_full(format="markdown")
+            slsa_attestations=[_make_slsa(verified=False)])).generate_full(output_format="markdown")
         assert "No" in report
     def test_unsuppressed_cves_rec(self):
         data = json.loads(ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"],
-            cve_scans=[_make_cve_scan()])).generate_full(format="json"))
+            cve_scans=[_make_cve_scan()])).generate_full(output_format="json"))
         assert any("unsuppressed" in r.lower() for r in data["recommendations"])
     def test_no_slsa_rec(self):
-        data = json.loads(ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"])).generate_full(format="json"))
+        data = json.loads(ReportGenerator(EvidenceBundle(repos=["lpasquali/rune"])).generate_full(output_format="json"))
         assert any("slsa" in r.lower() for r in data["recommendations"])
     def test_empty_full_json(self):
-        data = json.loads(ReportGenerator(EvidenceBundle(repos=[])).generate_full(format="json"))
+        data = json.loads(ReportGenerator(EvidenceBundle(repos=[])).generate_full(output_format="json"))
         assert data["sbom_analysis"]["total_components"] == 0 and data["slsa_verification"] == {}
     def test_unknown_license(self):
         bundle = EvidenceBundle(repos=["lpasquali/rune"],
             sboms=[SBOMDocument(bomFormat="CycloneDX", specVersion="1.5",
                 components=[SBOMComponent(name="nolicense", version="1.0")], source_repo="lpasquali/rune")])
-        data = json.loads(ReportGenerator(bundle).generate_full(format="json"))
+        data = json.loads(ReportGenerator(bundle).generate_full(output_format="json"))
         assert data["sbom_analysis"]["license_breakdown"]["Unknown"] == 1


### PR DESCRIPTION
## Summary
- Add `ReportGenerator` class in `rune_audit/reporters/report_generator.py` supporting full, summary, and delta reports
- Support markdown and JSON output formats with sections for executive summary, SBOM analysis, CVE findings, VEX status, SLSA verification, compliance matrix, and recommendations
- Wire up CLI stubs in `rune_audit/cli/report.py` with `--format` and `--output` options
- Add 36 comprehensive tests covering all report types, formats, and edge cases

Closes #22

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] Full report generates all required sections (Executive Summary, SBOM Analysis, CVE Findings, VEX Status, SLSA Verification, Compliance Matrix, Recommendations) — verified by test_sections_present
- [x] Summary report shows overall status, key metrics, critical findings — verified by TestGenerateSummary tests
- [x] Delta report shows new/resolved CVEs, new/removed components, compliance changes — verified by TestGenerateDelta tests  
- [x] Both markdown and JSON formats supported — verified by separate test classes
- [x] Edge cases handled (empty bundle, partial evidence) — verified by TestEdgeCases
- [x] Coverage: 98.30% (floor: 97%), report_generator.py at 99% — `pytest` output attached

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] 265 tests pass (229 existing + 36 new)
- [x] Coverage: 98.30% (above 97% floor)
- [x] report_generator.py coverage: 99%