### PR TITLE
chore: ignore Claude Code .claude/ agent state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Claude Code per-project agent state
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` to the `.gitignore` so Claude Code per-project agent state can never be accidentally committed
- Item in the cross-repo tracking issue lpasquali/rune-docs#199
- Defensive only — verified that no `.claude/` directory currently exists in this repo

Refs lpasquali/rune-docs#199

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] `.gitignore` now has a `.claude/` rule under a clearly labeled "Claude Code per-project agent state" section
- [x] No file content changes anywhere else
- [x] `git check-ignore .claude` returns the rule after this lands

## Audit Checks
No triggers fired.

## Breaking Changes
None.

## Test plan
- [x] Local: `git check-ignore .claude` reports the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)