### PR TITLE
feat(sr2): pluggable registry wiring and register_inspector

### DIFF
--- a/docs/OSS_PROJECTS.md
+++ b/docs/OSS_PROJECTS.md
@@ -5,6 +5,6 @@ security requirement catalog (IEC 62443-4-1 ML4 SR-2) used by RUNE.
 
 1. Add a `.rune-audit-project.yaml` at your repo root (see `rune_audit.sr2.project_config.default_project_template()` or run `rune-audit sr2 init`).
 2. Run `rune-audit sr2 verify --project .` from CI (see `rune-ci` workflow `sr2-compliance.yml`).
-3. Inspectors start as stubs (`not_implemented`) until you register real checks via `InspectorRegistry` (`rune_audit.sr2.registry`).
+3. Inspectors start as stubs (`not_implemented`) until you register real checks via `InspectorRegistry`, the `@register_inspector` decorator (built-ins loaded when `default_registry()` runs), or a custom registry passed to `run_verification(..., registry=...)`.
 
 Environment variables keep the `RUNE_AUDIT_*` prefix for historical compatibility.

--- a/rune_audit/sr2/engine.py
+++ b/rune_audit/sr2/engine.py
@@ -4,16 +4,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rune_audit.sr2.catalog import iter_requirements
 from rune_audit.sr2.inspectors import InspectContext, run_all
 from rune_audit.sr2.models import InspectStatus, Priority, VerifyReport
+
+if TYPE_CHECKING:
+    from rune_audit.sr2.registry import InspectorRegistry
 
 
 def run_verification(
     *,
     root: Path | None,
     priority: Priority | None,
+    registry: InspectorRegistry | None = None,
 ) -> VerifyReport:
     """Run all registered checks (stubs return NOT_IMPLEMENTED)."""
     specs = iter_requirements()
@@ -21,7 +26,7 @@ def run_verification(
         specs = tuple(s for s in specs if s.priority == priority)
     ctx_root = root.resolve() if root is not None else None
     ctx = InspectContext(root=ctx_root or Path("."))
-    results = run_all(ctx, specs)
+    results = run_all(ctx, specs, registry=registry)
     return VerifyReport(results=results, root=str(ctx_root) if ctx_root is not None else None)
 
 

--- a/rune_audit/sr2/inspectors.py
+++ b/rune_audit/sr2/inspectors.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING
 
 from rune_audit.sr2.models import InspectResult, InspectStatus, RequirementSpec
+
+if TYPE_CHECKING:
+    from rune_audit.sr2.registry import InspectorRegistry
 
 
 @dataclass
@@ -25,8 +29,13 @@ def stub_inspector(_ctx: InspectContext, spec: RequirementSpec) -> InspectResult
     )
 
 
-def run_all(ctx: InspectContext, specs: tuple[RequirementSpec, ...]) -> list[InspectResult]:
+def run_all(
+    ctx: InspectContext,
+    specs: tuple[RequirementSpec, ...],
+    *,
+    registry: InspectorRegistry | None = None,
+) -> list[InspectResult]:
     from rune_audit.sr2.registry import default_registry
 
-    reg = default_registry()
+    reg = registry if registry is not None else default_registry()
     return [reg.get(s.id)(ctx, s) for s in specs]

--- a/rune_audit/sr2/registry.py
+++ b/rune_audit/sr2/registry.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pluggable inspector registry (foundation for EPIC #228)."""
+"""Pluggable inspector registry (EPIC #228)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,23 @@ if TYPE_CHECKING:
     from rune_audit.sr2.inspectors import InspectContext
 
 InspectorFn = Callable[["InspectContext", RequirementSpec], InspectResult]
+
+_BUILTIN_INSPECTORS: list[tuple[str, InspectorFn]] = []
+
+
+def register_inspector(requirement_id: str) -> Callable[[InspectorFn], InspectorFn]:
+    """Decorator to register a built-in inspector (runs at import time).
+
+    Register modules under ``rune_audit.sr2`` (or import them before
+    :func:`default_registry` is called) so decorators execute and populate
+    ``_BUILTIN_INSPECTORS``.
+    """
+
+    def decorator(fn: InspectorFn) -> InspectorFn:
+        _BUILTIN_INSPECTORS.append((requirement_id, fn))
+        return fn
+
+    return decorator
 
 
 class InspectorRegistry:
@@ -32,5 +49,14 @@ class InspectorRegistry:
 
 
 def default_registry() -> InspectorRegistry:
-    """Registry used by the CLI until real inspectors land (#211)."""
-    return InspectorRegistry()
+    """Registry used by the CLI: built-ins from decorators + empty shell.
+
+    Imports :mod:`rune_audit.sr2.standard_inspectors` for side effects (future
+    ``@register_inspector`` entries).
+    """
+    import rune_audit.sr2.standard_inspectors  # noqa: F401
+
+    reg = InspectorRegistry()
+    for rid, fn in _BUILTIN_INSPECTORS:
+        reg.register(rid, fn)
+    return reg

--- a/rune_audit/sr2/standard_inspectors.py
+++ b/rune_audit/sr2/standard_inspectors.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Standard inspector entry points (EPIC #230) — re-export registry helpers."""
+"""Standard inspector entry points (EPIC #230).
+
+Use :func:`register_inspector` here (``@register_inspector("SR-Q-00N")``) so
+built-ins are collected when :func:`~rune_audit.sr2.registry.default_registry`
+runs.
+"""
 
 from rune_audit.sr2.inspectors import InspectContext, stub_inspector
-from rune_audit.sr2.registry import InspectorRegistry, default_registry
+from rune_audit.sr2.registry import InspectorRegistry, register_inspector
 
 __all__ = [
     "InspectContext",
     "InspectorRegistry",
-    "default_registry",
+    "register_inspector",
     "stub_inspector",
 ]

--- a/tests/test_sr2_catalog.py
+++ b/tests/test_sr2_catalog.py
@@ -95,3 +95,41 @@ def test_standard_inspectors_reexport() -> None:
     import rune_audit.sr2.standard_inspectors as si
 
     assert si.stub_inspector is not None
+    assert si.register_inspector is not None
+
+
+def test_register_inspector_decorator(monkeypatch, tmp_path) -> None:
+    from pathlib import Path
+
+    import rune_audit.sr2.registry as reg_mod
+    from rune_audit.sr2.inspectors import InspectContext
+    from rune_audit.sr2.models import InspectResult, InspectStatus, RequirementSpec
+
+    monkeypatch.setattr(reg_mod, "_BUILTIN_INSPECTORS", [])
+
+    @reg_mod.register_inspector("SR-Q-036")
+    def _bump(_ctx, spec: RequirementSpec) -> InspectResult:
+        return InspectResult(requirement_id=spec.id, status=InspectStatus.PASS, detail="decorator-test")
+
+    r = reg_mod.default_registry()
+    ctx = InspectContext(root=Path(tmp_path))
+    spec = RequirementSpec(id="SR-Q-036", title="t", priority=Priority.P2)
+    assert r.get("SR-Q-036")(ctx, spec).status == InspectStatus.PASS
+
+
+def test_run_verification_with_custom_registry(tmp_path) -> None:
+    from pathlib import Path
+
+    from rune_audit.sr2.models import InspectResult, InspectStatus, RequirementSpec
+    from rune_audit.sr2.registry import InspectorRegistry
+
+    reg = InspectorRegistry()
+
+    def always_pass(_ctx, spec: RequirementSpec) -> InspectResult:
+        return InspectResult(requirement_id=spec.id, status=InspectStatus.PASS, detail="custom")
+
+    reg.register("SR-Q-001", always_pass)
+    report = run_verification(root=Path(tmp_path), priority=None, registry=reg)
+    by_id = {r.requirement_id: r for r in report.results}
+    assert by_id["SR-Q-001"].status == InspectStatus.PASS
+    assert by_id["SR-Q-002"].status == InspectStatus.NOT_IMPLEMENTED


### PR DESCRIPTION
## Summary

Wire **SR-2** verification to optional **`InspectorRegistry`** instances: **`run_verification(..., registry=...)`** and **`run_all(..., registry=...)`**. Add **`@register_inspector`** decorator and **`_BUILTIN_INSPECTORS`** list; **`default_registry()`** imports **`standard_inspectors`** and applies decorated built-ins. **`standard_inspectors`** re-exports **`register_inspector`** (drops **`default_registry`** re-export — import from **`rune_audit.sr2.registry`**). Tests cover decorator isolation (**monkeypatch**) and per-run custom registry. **`docs/OSS_PROJECTS.md`** updated.

Closes lpasquali/rune-docs#228

Epic: lpasquali/rune-docs#208

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes (`pytest`, 97%+ coverage maintained)
- [x] Coverage not degraded
- [x] No unintended CI side effects (no workflow edits)

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] Registry **`register` / `get`** — existing + new tests
- [x] **`register_inspector`** decorator — `test_register_inspector_decorator` with **`monkeypatch`**
- [x] **`run_verification(..., registry=)`** — `test_run_verification_with_custom_registry`
- [x] Standard inspectors module documents decorator pattern; built-ins can register on import when added

## Test Plan Evidence

- [x] `ruff check` on touched paths
- [x] Full `pytest` (422 passed, 1 xfailed pre-existing)

## Breaking Changes

**`rune_audit.sr2.standard_inspectors`** no longer re-exports **`default_registry`**; use **`from rune_audit.sr2.registry import default_registry`**.

## Notes for Reviewer

- Config-driven inspector selection and external plugin entry points remain follow-on (#228 / future issues).
- Merge before or with rune-docs PR **docs/228-custom-inspectors-update** so published docs match API.
