### PR TITLE
ci: add standalone CodeQL workflow (rune pattern)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Code Scanning (CodeQL)
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  schedule:
+    - cron: "0 3 * * 1" # Weekly on Monday at 03:00 UTC
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: CodeQL/Python
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## Summary

Add standalone **Code Scanning (CodeQL)** for Python, matching **`rune/.github/workflows/codeql.yml`** (triggers, pins, `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`).

Closes #85

Epic: (none)

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

N/A (Level 2).

## Level 2 Checklist

- [x] Full test suite passes (unchanged code paths; CI will confirm)
- [x] Coverage not degraded (no application code change)
- [x] No unintended CI side effects (new workflow only)

## Level 3 Checklist

N/A (Level 2).

## Audit Checks

No triggers fired. (Workflow-only change; no deps, API, Dockerfile, or Helm chart edits.)

## Acceptance Criteria Evidence

- [x] **Workflow matches rune pattern** — evidence: diff vs `rune` `codeql.yml` in PR; issue #85
- [x] **CI green** — evidence: GitHub Actions checks on this PR

## Test Plan Evidence

- [x] **PR CI** — Quality Gates + new CodeQL workflow run on this branch

## Breaking Changes

None.
