### PR TITLE
chore(ci): adopt rune-ci@eae1383 merge gate policy

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,36 +16,28 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@95f0b3fd7c0cdbab72a42e71343c27125997bca5 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@95f0b3fd7c0cdbab72a42e71343c27125997bca5 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       source-dirs: "rune_audit"
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
       allowed-license-exceptions: "bashlex,borb"
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@95f0b3fd7c0cdbab72a42e71343c27125997bca5 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
 
   container:
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@95f0b3fd7c0cdbab72a42e71343c27125997bca5 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       image-name: "rune-audit"
 
   compliance:
     needs: [security, python, integration, container]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@95f0b3fd7c0cdbab72a42e71343c27125997bca5 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       needs-json: ${{ toJson(needs) }}
-
-  merge-gate:
-    name: Merge Gate
-    needs: [compliance]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Merge Gate Satisfied"


### PR DESCRIPTION
## Summary

Pins `lpasquali/rune-ci` reusable workflows to `eae13830420fe3b9d558edb081c01c90bdc01d03` and removes the redundant top-level `merge-gate` job so the **Merge Gate** enforced inside `pr-compliance` is authoritative (SoD / epic https://github.com/lpasquali/rune-ci/issues/25).

Fixes #89

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes (via Quality Gates on this PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects (workflow-only change)

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| (n/a) | PASS | No audit triggers per SYSTEM_PROMPT |

## Acceptance Criteria Evidence

- [x] Workflow pins and merge-gate wiring match SoD follow-up issue — evidence: this PR diff and green Quality Gates.

## Test Plan Evidence

- [x] CI-only change; validated by repository Quality Gates workflow on this PR.

## Breaking Changes

None.

## Notes for Reviewer

Part of SoD remediation after unreviewed `rune-ci` `main` push (retro https://github.com/lpasquali/rune-ci/issues/26).
