### PR TITLE
chore(ci): bump rune-ci to 40149ab (workflow_call merge-gate fix)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,28 +16,28 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       source-dirs: "rune_audit"
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
       allowed-license-exceptions: "bashlex,borb"
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
 
   container:
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       image-name: "rune-audit"
 
   compliance:
     needs: [security, python, integration, container]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       needs-json: ${{ toJson(needs) }}


### PR DESCRIPTION
## Summary
Bumps `lpasquali/rune-ci` pins after https://github.com/lpasquali/rune-ci/commit/40149ab6e8d7305f01d31d3e53caa4da1361177b — `pr-compliance` must reference `merge-gate-verify` via `lpasquali/rune-ci/actions/...` so `workflow_call` consumers resolve the action from rune-ci, not the caller checkout.

Hotfix after https://github.com/lpasquali/rune-audit/pull/90 (pin `eae1383` was broken for callers).

## DoD Level
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist
- [x] CI-only pin update
- [x] Quality Gates expected to pass on this PR

## Audit Checks
No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| (n/a) | PASS | No audit triggers |

## Acceptance Criteria Evidence
- [x] Pin matches hotfix commit — evidence: this diff.

## Breaking Changes
None.

Epic: https://github.com/lpasquali/rune-ci/issues/25