### PR TITLE
ci: disable Ollama integration for rune-audit

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -29,6 +29,7 @@ jobs:
     uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
+      ollama-enabled: false
 
   container:
     uses: lpasquali/rune-ci/.github/workflows/container-build.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main


### PR DESCRIPTION
## Summary

rune-audit does not need live Ollama integration tests; pass `ollama-enabled: false` to the shared `python-integration` workflow.

## Definition of Done

- [x] **Level 1**
- [ ] **Level 2**
- [ ] **Level 3**

## Acceptance Criteria Evidence

- `integration` job in `quality-gates.yml` passes `ollama-enabled: false`; smoke and other jobs unchanged.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)