### PR TITLE
test: skip heavy SR-2 placeholder until inspectors land

### DIFF
--- a/tests/test_sr2_future_inspectors.py
+++ b/tests/test_sr2_future_inspectors.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Placeholder tests for full SR-2 automation (rune-docs #211 / #215)."""
+"""Placeholder for full SR-2 automation (rune-docs #211 / #215).
+
+Previously marked xfail, the body still ran ``run_verification`` on every CI
+pass (expensive for no signal). Skip until inspectors land; keep the body for
+when the skip is removed.
+"""
 
 import pytest
 
 
-@pytest.mark.xfail(reason="Real per-requirement inspectors not merged yet (lpasquali/rune-docs#211).", strict=False)
+@pytest.mark.skip(reason="SR-Q inspectors not complete yet (lpasquali/rune-docs#211); avoids heavy run_verification each CI pass.")
 def test_all_sr2_inspectors_implemented() -> None:
     from rune_audit.sr2.engine import run_verification
 


### PR DESCRIPTION
## Summary

Replace `@pytest.mark.xfail` with `@pytest.mark.skip` on the SR-2 “all inspectors implemented” placeholder so CI no longer runs a full `run_verification()` pass that always fails the assertion anyway. Behavior for real work is unchanged until rune-docs#211 lands.

Closes #99

Part of audit #88 / epic https://github.com/lpasquali/rune-docs/issues/249

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 1 Checklist

Skipped (Level 2).

## Level 2 Checklist

- [x] Full test suite passes
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects

## Level 3 Checklist

Skipped (Level 2).

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| *(none)* | — | — |

## Acceptance Criteria Evidence

- [x] Placeholder no longer executes heavy `run_verification` each pass — evidence: `pytest` summary shows skip instead of xfail
- [x] Body kept for future enablement — evidence: `tests/test_sr2_future_inspectors.py`

## Test Plan Evidence

- [x] `pytest tests/` locally — 525 passed, 3 skipped

## Breaking Changes

None.
