### PR TITLE
docs(readme): hyperlink standards and tools to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Auditing and compliance tracking for the
 [RUNE](https://github.com/lpasquali/rune) platform.
 
 rune-audit collects, verifies, and reports on security and compliance evidence
-across the RUNE ecosystem. It verifies SLSA Level 3 build provenance, manages
-VEX (Vulnerability Exploitability eXchange) documents, and generates IEC 62443
+across the RUNE ecosystem. It verifies [SLSA Level 3](https://slsa.dev/spec/v1.0/)
+build provenance, manages [VEX (Vulnerability Exploitability eXchange)](https://github.com/openvex/spec)
+documents, and generates [IEC 62443](https://webstore.iec.ch/publication/33615)
 evidence matrices.
 
 ## Architecture
@@ -77,11 +78,11 @@ Multi-repo SR-2 matrix (HTML / JSON / Markdown): `rune-audit sr2 dashboard --bas
 
 | Type | Description | Source |
 |------|-------------|--------|
-| SLSA Provenance | Build attestation verification | GitHub Attestations API |
-| SBOM | Software Bill of Materials | CycloneDX / SPDX |
-| CVE Scans | Vulnerability scan results | pip-audit, grype |
-| VEX | Vulnerability Exploitability eXchange | OpenVEX documents |
-| License | License compliance status | SPDX headers, LICENSE files |
+| [SLSA Provenance](https://slsa.dev/spec/v1.0/provenance) | Build attestation verification | GitHub Attestations API |
+| SBOM | Software Bill of Materials | [CycloneDX](https://cyclonedx.org/specification/overview/) / [SPDX](https://spdx.dev/) |
+| CVE Scans | Vulnerability scan results | [pip-audit](https://pypi.org/project/pip-audit/), [grype](https://github.com/anchore/grype) |
+| VEX | Vulnerability Exploitability eXchange | [OpenVEX](https://github.com/openvex/spec) documents |
+| License | License compliance status | [SPDX](https://spdx.dev/) headers, LICENSE files |
 
 ## Configuration
 
@@ -95,9 +96,9 @@ Optional YAML config file: `rune-audit.yaml`
 
 ## Compliance Context
 
-- **IEC 62443-4-1 ML4**: This repository aligns with IEC 62443-4-1 Maturity
-  Level 4 secure development requirements.
-- **SLSA Level 3**: Build provenance is verified against all five SLSA L3
+- **[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) ML4**: This repository aligns with IEC 62443-4-1 Maturity
+  Level 4 secure development requirements. ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- **[SLSA Level 3](https://slsa.dev/spec/v1.0/)**: Build provenance is verified against all five SLSA L3
   requirements (provenance exists, signed, trusted builder, version-controlled
   source, isolated build).
 


### PR DESCRIPTION
## Summary

Hyperlinks IEC 62443-4-1, SLSA (v1.0 + Provenance), OpenVEX, CycloneDX, SPDX, pip-audit, and grype in the README to their official URLs. URLs from the rune-docs External Links Catalog.

Closes #103
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] Manual diff review
- [x] All target URLs resolve (HTTP 200/301)

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] IEC 62443-4-1 → IEC Webstore + ISA overview — `README.md` diff (intro para + Compliance section)
- [x] SLSA Level 3 + Provenance → slsa.dev/spec/v1.0 — `README.md` diff
- [x] OpenVEX → github.com/openvex/spec — `README.md` diff
- [x] CycloneDX → cyclonedx.org — `README.md` Evidence Types table
- [x] SPDX → spdx.dev — `README.md` Evidence Types table (two occurrences)
- [x] pip-audit → pypi.org — `README.md` Evidence Types table
- [x] grype → github.com/anchore/grype — `README.md` Evidence Types table

## Test Plan Evidence

- [x] Diff review: 1 file, 3 blocks modified
- [x] All target URLs return 2xx/3xx

## Breaking Changes

None.

## Notes for Reviewer

Cross-repo sweep companion to rune-docs PR #307, rune#268, rune-operator#116, rune-ui#140, rune-charts#104, rune-airgapped#90.