### PR TITLE
Consolidate Dependabot updates and update rune-ci pins

### DIFF
--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,33 +16,33 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   python:
-    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-quality.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       source-dirs: "rune_audit"
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
       allowed-license-exceptions: "bashlex,borb"
 
   integration:
-    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/python-integration.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       path-filter: "^(rune_audit/|tests/|requirements\\.txt|pyproject\\.toml)"
       ollama-enabled: false
 
   container:
-    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/container-build.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       image-name: "rune-audit"
 
   guard:
-    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/nginx-ingress-guard.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
 
   compliance:
     needs: [security, python, integration, container, guard]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       needs-json: ${{ toJson(needs) }}
       merge-gate-excludes: "guard" # Force pass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   release:
-    uses: lpasquali/rune-ci/.github/workflows/release.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
+    uses: lpasquali/rune-ci/.github/workflows/release.yml@144ef855dbf0420e5d9a8de2c8d8f89c2e789265
     with:
       image-name: "rune-audit"
       generate-sbom: true

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -25,7 +25,7 @@ jobs:
     name: Collect evidence
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -79,7 +79,7 @@ jobs:
           rune-audit report summary --format markdown --output audit-output/summary.md 2>&1 || echo "Summary report generated with warnings"
 
       - name: Upload evidence bundle and reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: audit-evidence-${{ github.run_id }}
           path: audit-output/
@@ -90,7 +90,7 @@ jobs:
     needs: [collect]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:


### PR DESCRIPTION
## Summary

Consolidated pending Dependabot GitHub Action updates and updated `rune-ci` reusable workflow pins to the latest baseline.

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Verified workflow YAML syntax
- [x] **CI impact audit**: No changes to build/test logic, only version bumps.
- [x] Verified pinned SHAs match upstream releases.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `supply-chain check:actions` | PASS | All actions updated to latest pinned SHAs. |

## Acceptance Criteria Evidence

- [x] All GitHub Actions bumped to versions requested by Dependabot.
- [x] All `rune-ci` reusable workflows pinned to SHA `144ef855...`.

## Breaking Changes

None.

## Notes for Reviewer

This PR cleans up automated noise by grouping several Dependabot updates into a single atomic change.
